### PR TITLE
Update wrensec-commons to 22.0.0 (#3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 
     <properties>
         <!-- Commons forgerock-rest versions -->
-        <commons.commons-bom.version>21.0.0-alpha-17</commons.commons-bom.version>
+        <commons.commons-bom.version>22.0.0</commons.commons-bom.version>
 
         <commons.script.osgi.import.before.defaults />
         <commons.script.osgi.import.defaults />

--- a/script-common/pom.xml
+++ b/script-common/pom.xml
@@ -115,7 +115,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/script-groovy/pom.xml
+++ b/script-groovy/pom.xml
@@ -78,7 +78,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/script-javascript/pom.xml
+++ b/script-javascript/pom.xml
@@ -109,7 +109,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
_Wrensec-commons_ dependency has been upgraded to our latest release **22.0.0-M1**. The project is fully buildable without any special build options.