### PR TITLE
Add ES6 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-script</artifactId>
-    <version>4.4.0-SNAPSHOT</version>
+    <version>4.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Wren Security Script Parent</name>

--- a/script-common/pom.xml
+++ b/script-common/pom.xml
@@ -27,10 +27,9 @@
     <parent>
         <groupId>org.forgerock.commons</groupId>
         <artifactId>forgerock-script</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.forgerock.commons</groupId>
     <artifactId>script-common</artifactId>
     <packaging>bundle</packaging>
 

--- a/script-groovy/pom.xml
+++ b/script-groovy/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.forgerock.commons</groupId>
         <artifactId>forgerock-script</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>script-groovy</artifactId>

--- a/script-javascript/pom.xml
+++ b/script-javascript/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.forgerock.commons</groupId>
         <artifactId>forgerock-script</artifactId>
-        <version>4.4.0-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>script-javascript</artifactId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.rhino</artifactId>
-            <version>1.7R4_1</version>
+            <version>1.7.13_1</version>
         </dependency>
 
         <dependency>

--- a/script-javascript/pom.xml
+++ b/script-javascript/pom.xml
@@ -56,9 +56,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.rhino</artifactId>
-            <version>1.7.13_1</version>
+            <groupId>org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
+            <version>1.7.13</version>
         </dependency>
 
         <dependency>
@@ -118,14 +118,6 @@
             <artifactId>script-common</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- https://bugzilla.mozilla.org/show_bug.cgi?id=379385 -->
-        <dependency>
-            <groupId>org.mozilla</groupId>
-            <artifactId>rhino</artifactId>
-            <version>1.7R4</version>
             <scope>test</scope>
         </dependency>
 

--- a/script-javascript/src/main/java/org/forgerock/script/javascript/RhinoScript.java
+++ b/script-javascript/src/main/java/org/forgerock/script/javascript/RhinoScript.java
@@ -130,6 +130,7 @@ public class RhinoScript implements CompiledScript {
         this.engine = engine;
         this.requireBuilder = requireBuilder;
         Context cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
         try {
             scriptScope = getScriptScope(cx);
             script = compiledScript;
@@ -148,17 +149,7 @@ public class RhinoScript implements CompiledScript {
      * etc.) will be used for script execution; otherwise a new unsealed scope will be allocated for each execution.
      */
     public RhinoScript(String name, final RhinoScriptEngine engine, RequireBuilder requireBuilder, boolean sharedScope) {
-        this.scriptName = name;
-        this.sharedScope = sharedScope;
-        this.engine = engine;
-        this.requireBuilder = requireBuilder;
-        Context cx = Context.enter();
-        try {
-            scriptScope = getScriptScope(cx);
-            script = null;
-        } finally {
-            Context.exit();
-        }
+        this(name, null, engine, requireBuilder, sharedScope);
     }
 
     /**
@@ -243,6 +234,7 @@ public class RhinoScript implements CompiledScript {
             throws ScriptException {
 
         Context context = Context.enter();
+        context.setLanguageVersion(Context.VERSION_ES6);
         try {
             Scriptable outer = context.newObject(getStandardObjects(context));
 

--- a/script-javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngine.java
+++ b/script-javascript/src/main/java/org/forgerock/script/javascript/RhinoScriptEngine.java
@@ -237,6 +237,7 @@ public class RhinoScriptEngine extends AbstractScriptEngine {
 
     private Script compileScript(String name, Reader scriptReader) throws ScriptCompilationException {
         Context cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
         try {
             return cx.compileReader(scriptReader, name, 1, null);
         } catch (IOException ioe) {


### PR DESCRIPTION
The main purpose of this fix is to enable ES6 constructs such as `const` and `let` in configuration scripts.

Changes made:
* bumped Rhino version to 1.7.13_1 
*  set language version `VERSION_ES6` on every `Context.enter()`.

