### PR TITLE
Bring back rhino servicemix to solve commonJS issue (#10)

### DIFF
--- a/script-javascript/pom.xml
+++ b/script-javascript/pom.xml
@@ -56,9 +56,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mozilla</groupId>
-            <artifactId>rhino</artifactId>
-            <version>1.7.13</version>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.rhino</artifactId>
+            <version>1.7.13_1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I have brought back the servicemix Rhino bundle to solve an issue with commonJs not being exported by Rhino 1.7.13