### PR TITLE
Fix unwanted global scope sharing between scripts and modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,5 +89,9 @@ local.properties
 # sbteclipse plugin
 .target
 
+# TestNG
+*/test-output
+
 # TeXlipse plugin
 .texlipse
+

--- a/script-javascript/src/main/java/org/forgerock/script/javascript/RhinoScript.java
+++ b/script-javascript/src/main/java/org/forgerock/script/javascript/RhinoScript.java
@@ -108,6 +108,7 @@ public class RhinoScript implements CompiledScript {
      * Proxy class to avoid proliferation of anonymous classes.
      */
     private static class IProxy implements QuitAction {
+        @Override
         public void quit(Context cx, int exitCode) {
             /* no quit :) */
         }
@@ -224,6 +225,7 @@ public class RhinoScript implements CompiledScript {
         return name.indexOf("/") != -1 ? name.substring(name.lastIndexOf("/") + 1) : name;
     }
 
+    @Override
     public Bindings prepareBindings(org.forgerock.services.context.Context context, Bindings request, Bindings... scopes) {
         // TODO Fix it later
         return new SimpleBindings();
@@ -289,7 +291,7 @@ public class RhinoScript implements CompiledScript {
 
             // install require function per unofficial CommonJS author documentation
             // https://groups.google.com/d/msg/mozilla-rhino/HCMh_lAKiI4/P1MA3sFsNKQJ
-            requireBuilder.createRequire(context, inner).install(inner);
+            requireBuilder.createRequire(context, outer).install(inner);
 
             final Script scriptInstance = null != script ? script : engine.createScript(scriptName);
             Object result = Converter.convert(scriptInstance.exec(context, inner));
@@ -337,6 +339,7 @@ public class RhinoScript implements CompiledScript {
             super(parent);
         }
 
+        @Override
         public Class<?> loadClass(String name) throws ClassNotFoundException {
             // First check whether it's already been loaded, if so use it
             Class loadedClass = Kit.classOrNull(getParent(), name);

--- a/script-javascript/src/test/java/org/forgerock/script/javascript/RhinoScriptTest.java
+++ b/script-javascript/src/test/java/org/forgerock/script/javascript/RhinoScriptTest.java
@@ -1,0 +1,96 @@
+package org.forgerock.script.javascript;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.script.SimpleBindings;
+import org.forgerock.script.ScriptName;
+import org.forgerock.script.engine.CompilationHandler;
+import org.forgerock.script.engine.CompiledScript;
+import org.forgerock.script.source.DirectoryContainer;
+import org.forgerock.script.source.ScriptSource;
+import org.forgerock.script.source.SourceContainer;
+import org.forgerock.script.source.SourceUnit;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class RhinoScriptTest {
+
+    private SourceContainer container;
+
+    private RhinoScriptEngine engine;
+
+    @BeforeClass
+    public void initEngine() throws Exception {
+        ClassLoader classLoader = RhinoScriptTest.class.getClassLoader();
+
+        container = new DirectoryContainer("test", classLoader.getResource("scripts/"));
+
+        engine = (RhinoScriptEngine) new RhinoScriptEngineFactory().getScriptEngine(
+                Collections.emptyMap(),
+                Collections.singleton(container),
+                classLoader);
+    }
+
+
+    public CompiledScript loadScript(String name) throws Exception {
+        ScriptSource source = container.findScriptSource(new ScriptName(name, SourceUnit.AUTO_DETECT));
+
+        AtomicReference<CompiledScript> result = new AtomicReference<CompiledScript>();
+        engine.compileScript(new CompilationHandler() {
+            @Override
+            public void setCompiledScript(CompiledScript script) {
+                result.set(script);
+            }
+
+            @Override
+            public void setClassLoader(ClassLoader classLoader) {
+            }
+
+            @Override
+            public void handleException(Exception exception) {
+                throw new IllegalStateException(exception);
+            }
+
+            @Override
+            public ScriptSource getScriptSource() {
+                return source;
+            }
+
+            @Override
+            public ClassLoader getParentClassLoader() {
+                return null;
+            }
+        });
+        return result.get();
+    }
+
+
+    @Test
+    public void testSimpleEval() throws Exception {
+        Object result = loadScript("simple.js").eval(null, null);
+        assertEquals(result, "HELLO WORLD");
+    }
+
+    @Test
+    public void testModuleLoad() throws Exception {
+        Object result = loadScript("main.js").eval(null, null);
+        assertEquals(result, "HELLO MODULE!");
+    }
+
+    @Test
+    public void testModuleGlobal() throws Exception {
+        Object result = loadScript("main.js").eval(null, new SimpleBindings(Map.of("welcomeName", "BINDING")));
+        assertEquals(result, "HELLO BINDING!");
+    }
+
+    @Test
+    public void testRepeatedCall() throws Exception {
+        CompiledScript script = loadScript("main.js");
+        script.eval(null, null);
+        script.eval(null, null);
+    }
+
+}

--- a/script-javascript/src/test/resources/scripts/main.js
+++ b/script-javascript/src/test/resources/scripts/main.js
@@ -1,0 +1,2 @@
+const name = require('module.js').value;
+name + "!";

--- a/script-javascript/src/test/resources/scripts/module.js
+++ b/script-javascript/src/test/resources/scripts/module.js
@@ -1,0 +1,2 @@
+const name = typeof welcomeName !== "undefined" ? welcomeName : "MODULE";
+module.exports.value =  `HELLO ${name}`;

--- a/script-javascript/src/test/resources/scripts/simple.js
+++ b/script-javascript/src/test/resources/scripts/simple.js
@@ -1,0 +1,1 @@
+"HELLO WORLD";


### PR DESCRIPTION
This PR fixes scope sharing of top-level script scope with CommonJS modules. The issue is demonstrated in the newly added unit tests.