### PR TITLE
Upgrade RhinoJS to 1.7.15.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17]
+        java: [17, 21]
     name: "Java ${{ matrix.java }} build"
     steps:
       - uses: actions/checkout@v2

--- a/script-javascript/pom.xml
+++ b/script-javascript/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.rhino</artifactId>
-            <version>1.7.14_2</version>
+            <version>1.7.15_1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR upgrades RhinoJS to the latest release and also upgrade the JDK version in the GitHub CI pipeline.